### PR TITLE
TASK: Throw exception for client and server error

### DIFF
--- a/Classes/Exception.php
+++ b/Classes/Exception.php
@@ -20,4 +20,11 @@ use TYPO3\Flow\Http;
  */
 class Exception extends Http\Exception
 {
+    /**
+     * @param integer $statusCode
+     * @return void
+     */
+    public function setStatusCode($statusCode) {
+        $this->statusCode = $statusCode;
+    }
 }

--- a/Classes/RedirectService.php
+++ b/Classes/RedirectService.php
@@ -65,6 +65,7 @@ class RedirectService
             }
             return $this->buildResponse($httpRequest, $redirect);
         } catch (\Exception $exception) {
+            // Throw exception if it's a \Neos\RedirectHandler\Exception (used for custom exception handling)
             if ($exception instanceof Exception) {
                 throw $exception;
             }

--- a/Classes/RedirectService.php
+++ b/Classes/RedirectService.php
@@ -65,6 +65,9 @@ class RedirectService
             }
             return $this->buildResponse($httpRequest, $redirect);
         } catch (\Exception $exception) {
+            if ($exception instanceof Exception) {
+                throw $exception;
+            }
             // skip triggering the redirect if there was an error accessing the database (wrong credentials, ...)
             return null;
         }
@@ -89,6 +92,10 @@ class RedirectService
                 'Cache-Control' => 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0',
                 'Expires' => 'Sat, 26 Jul 1997 05:00:00 GMT'
             ]));
+        } elseif ($statusCode >= 400 && $statusCode <= 599) {
+            $exception = new Exception();
+            $exception->setStatusCode($statusCode);
+            throw $exception;
         }
         return $response;
     }


### PR DESCRIPTION
This allows for using Flow exception handling to display an exception according to the error.
E.g. enabling using ``404`` exception handling for ``410`` status codes.