### PR TITLE
FEATURE: Handle 410 - gone status without exceptions

### DIFF
--- a/Classes/RedirectComponent.php
+++ b/Classes/RedirectComponent.php
@@ -37,6 +37,12 @@ class RedirectComponent implements ComponentInterface
     protected $redirectService;
 
     /**
+     * @Flow\InjectConfiguration(path="cancelHttpChain")
+     * @var boolean
+     */
+    protected $cancelHttpChain;
+
+    /**
      * Check if the current request match a redirect
      *
      * @param ComponentContext $componentContext
@@ -52,7 +58,9 @@ class RedirectComponent implements ComponentInterface
         $response = $this->redirectService->buildResponseIfApplicable($httpRequest);
         if ($response !== null) {
             $componentContext->replaceHttpResponse($response);
-            $componentContext->setParameter(ComponentChain::class, 'cancel', true);
+            if ($this->cancelHttpChain) {
+                $componentContext->setParameter(ComponentChain::class, 'cancel', true);
+            }
         }
     }
 }

--- a/Classes/RedirectComponent.php
+++ b/Classes/RedirectComponent.php
@@ -51,7 +51,7 @@ class RedirectComponent implements ComponentInterface
     public function handle(ComponentContext $componentContext)
     {
         $routingMatchResults = $componentContext->getParameter(RoutingComponent::class, 'matchResults');
-        if ($routingMatchResults !== NULL) {
+        if ($routingMatchResults !== null) {
             return;
         }
         $httpRequest = $componentContext->getHttpRequest();

--- a/Classes/RedirectService.php
+++ b/Classes/RedirectService.php
@@ -100,9 +100,7 @@ class RedirectService
             $response = $response->withHeader('Location', $location);
             $response = $response->withHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
             $response = $response->withHeader('Expires', 'Sat, 26 Jul 1997 05:00:00 GMT');
-
         } elseif ($statusCode >= 400 && $statusCode <= 599) {
-
             $responseBody = '
                 <!DOCTYPE html>
                 <html>
@@ -128,7 +126,7 @@ class RedirectService
 
             $response = $response->withBody(
                 new \Neos\Flow\Http\ContentStream(
-                    fopen('data://text/plain,' . $responseBody,'r'),
+                    fopen('data://text/plain,' . $responseBody, 'r'),
                     'r'
                 )
             );

--- a/Classes/RedirectService.php
+++ b/Classes/RedirectService.php
@@ -85,10 +85,9 @@ class RedirectService
             return null;
         }
 
-        $statusCode = $redirect->getStatusCode();
-
         $response = new Response();
-        $response = $response->withStatus($statusCode);
+        $statusCode = $redirect->getStatusCode();
+        $response->setStatus($statusCode);
 
         if ($statusCode >= 300 && $statusCode <= 399) {
             $location = $redirect->getTargetUriPath();
@@ -97,11 +96,13 @@ class RedirectService
                 $location = $httpRequest->getBaseUri() . $location;
             }
 
-            $response = $response->withHeader('Location', $location);
-            $response = $response->withHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0');
-            $response = $response->withHeader('Expires', 'Sat, 26 Jul 1997 05:00:00 GMT');
+            $response->setHeaders(new Headers([
+                'Location' => $location,
+                'Cache-Control' => 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0',
+                'Expires' => 'Sat, 26 Jul 1997 05:00:00 GMT'
+            ]));
         } elseif ($statusCode >= 400 && $statusCode <= 599) {
-            $responseBody = '
+            $content = '
                 <!DOCTYPE html>
                 <html>
                     <head>
@@ -124,12 +125,7 @@ class RedirectService
                     </body>
                 </html>';
 
-            $response = $response->withBody(
-                new \Neos\Flow\Http\ContentStream(
-                    fopen('data://text/plain,' . $responseBody, 'r'),
-                    'r'
-                )
-            );
+            $response->setContent($content);
         }
 
         return $response;

--- a/Classes/RedirectService.php
+++ b/Classes/RedirectService.php
@@ -16,6 +16,7 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Headers;
 use Neos\Flow\Http\Request as Request;
 use Neos\Flow\Http\Response;
+use Neos\Flow\Http\Helper\ResponseInformationHelper;
 use Neos\Flow\Mvc\Routing\RouterCachingService;
 
 /**
@@ -102,12 +103,13 @@ class RedirectService
                 'Expires' => 'Sat, 26 Jul 1997 05:00:00 GMT'
             ]));
         } elseif ($statusCode >= 400 && $statusCode <= 599) {
+            $statusMessage = ResponseInformationHelper::getStatusMessageByCode($statusCode);
             $content = '
                 <!DOCTYPE html>
                 <html>
                     <head>
                         <meta charset="UTF-8">
-                        <title>' . $statusCode . ' Gone</title>
+                        <title>' . $statusCode . ' ' . $statusMessage . '</title>
                         <style type="text/css">
                             body {
                                 font-family: Helvetica, Arial, sans-serif;
@@ -121,7 +123,7 @@ class RedirectService
                         </style>
                     </head>
                     <body>
-                        <h1>' . $statusCode . ' Gone</h1>
+                        <h1>' . $statusCode . ' ' . $statusMessage . '</h1>
                     </body>
                 </html>';
 

--- a/Configuration/Settings.yaml
+++ b/Configuration/Settings.yaml
@@ -6,6 +6,7 @@ Neos:
     statusCode:
       redirect: 307
       gone: 410
+    cancelHttpChain: true
   Flow:
     http:
       chain:


### PR DESCRIPTION
Avoid throwing an exception for gone pages and render a http response instead.

Additionally a setting is added to avoid the cancelling of the http-chain after creating a new response. This allows to integrate other components that improve the response of this package. By rendering a nice 410 page.