### PR TITLE
FEATURE: Allow redirect in case of hidden node

### DIFF
--- a/Classes/RedirectComponent.php
+++ b/Classes/RedirectComponent.php
@@ -60,8 +60,8 @@ class RedirectComponent implements ComponentInterface
     public function handle(ComponentContext $componentContext)
     {
         $routingMatchResults = $componentContext->getParameter(RoutingComponent::class, 'matchResults');
-        if ($routingMatchResults !== NULL) {
-            if(isset($routingMatchResults['node'])){
+        if ($routingMatchResults !== null) {
+            if (isset($routingMatchResults['node'])) {
                 $nodePathIncludingContextAndDimensions = $routingMatchResults['node'];
                 $node = null;
                 $this->securityContext->withoutAuthorizationChecks(function () use ($nodePathIncludingContextAndDimensions, &$node) {
@@ -69,12 +69,11 @@ class RedirectComponent implements ComponentInterface
                 });
 
                 // if the node is found there is no need to redirect, thus return
-                if($node instanceof NodeInterface){
+                if ($node instanceof NodeInterface) {
                     return;
                 }
                 // in case the node is hidden, convertFrom() will return an Error() and thus redirect if applicable
-            }
-            else{
+            } else {
                 return;
             }
         }


### PR DESCRIPTION
This is a fix for issue #39, but to be honest I'm not sure it's a good one because of my lack of knowledge on neos internals.

This PR basically converts the a node path available by `matchResults` into a node. If the node is available - e.g. not hidden - the redirect will be not be used. If the node is not available the redirect handling is done.

My concerns with this are:
1. I don't know why I need the `withoutAuthorizationChecks` call. The NodeConverter itself has the securityContext injected, but doesn't use it. So the need for `withoutAuthorizationChecks` might be due to some sideeffect where the security context is not yet initalized when the redirect handler is running?
2. Since I'm using NodeInterface and NodeConverter, these changes tightly couple the redirecthandler to the ContentRepository. So, I'm not sure if I need to change composer.json or what to add there?
3. I'm not sure if it's ok to directly use NodeConverter->convertFrom() without some kind of PropertyMapper. It works, but I'm not sure if it is kind of good practice?