### PR TITLE
BUGFIX: Explicitly define import & export format

### DIFF
--- a/Classes/Service/RedirectImportService.php
+++ b/Classes/Service/RedirectImportService.php
@@ -36,7 +36,7 @@ class RedirectImportService
     const REDIRECT_IMPORT_MESSAGE_TYPE_UNCHANGED = 'unchanged';
     const REDIRECT_IMPORT_MESSAGE_TYPE_ERROR = 'error';
 
-    const REDIRECT_EXPORT_DATETIME_FORMAT = 'c';
+    const REDIRECT_EXPORT_DATETIME_FORMAT = 'Y-m-d\TH:i:sP';
 
     /**
      * @Flow\Inject


### PR DESCRIPTION
Sometimes imports of previously exported redirects
didn’t work even though the same shortcut format was used.

Also this helps when the import fails as the desired format will be 
shown in the error message.