### PR TITLE
BUGFIX: Explicitly define import & export format

### DIFF
--- a/Classes/Service/RedirectImportService.php
+++ b/Classes/Service/RedirectImportService.php
@@ -35,7 +35,7 @@ class RedirectImportService
     const REDIRECT_IMPORT_MESSAGE_TYPE_UNCHANGED = 'unchanged';
     const REDIRECT_IMPORT_MESSAGE_TYPE_ERROR = 'error';
 
-    const REDIRECT_EXPORT_DATETIME_FORMAT = 'c';
+    const REDIRECT_EXPORT_DATETIME_FORMAT = 'Y-m-d\TH:i:sP';
 
     /**
      * @Flow\Inject


### PR DESCRIPTION
Sometimes imports of previously exported redirects
didn’t work even though the same shortcut format was used.

Same as #41 but for 3.x branch