### PR TITLE
BUGFIX: Convert relative redirects correctly

### DIFF
--- a/Classes/RedirectComponent.php
+++ b/Classes/RedirectComponent.php
@@ -17,7 +17,6 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Component\ComponentChain;
 use Neos\Flow\Http\Component\ComponentContext;
 use Neos\Flow\Http\Component\ComponentInterface;
-use Neos\Flow\Mvc\Routing\RouterCachingService;
 use Neos\Flow\Mvc\Routing\RoutingComponent;
 
 /**
@@ -25,11 +24,6 @@ use Neos\Flow\Mvc\Routing\RoutingComponent;
  */
 class RedirectComponent implements ComponentInterface
 {
-    /**
-     * @var RouterCachingService
-     * @Flow\Inject
-     */
-    protected $routerCachingService;
 
     /**
      * @var RedirectService

--- a/Classes/RedirectService.php
+++ b/Classes/RedirectService.php
@@ -91,8 +91,25 @@ class RedirectService
         if ($statusCode >= 300 && $statusCode <= 399) {
             $location = $redirect->getTargetUriPath();
 
+            // Relative redirects will be turned into absolute redirects
             if (parse_url($location, PHP_URL_SCHEME) === null) {
-                $location = $httpRequest->getBaseUri() . $location;
+                $location = (string)$httpRequest->getUri()->withQuery('')->withFragment('')->withPath($location);
+                $locationParts = parse_url($location);
+                $location = $httpRequest->getUri();
+
+                if (isset($locationParts['path'])) {
+                    $location = $location->withPath($locationParts['path']);
+                }
+
+                if (isset($locationParts['query'])) {
+                    $location = $location->withQuery($locationParts['query']);
+                }
+
+                if (isset($locationParts['fragment'])) {
+                    $location = $location->withFragment($locationParts['fragment']);
+                }
+
+                $location = (string)$location;
             }
 
             $response->setHeaders(new Headers([

--- a/Classes/RedirectService.php
+++ b/Classes/RedirectService.php
@@ -16,7 +16,6 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Headers;
 use Neos\Flow\Http\Request as Request;
 use Neos\Flow\Http\Response;
-use Neos\Flow\Mvc\Routing\RouterCachingService;
 
 /**
  * Central authority for HTTP redirects.
@@ -33,12 +32,6 @@ class RedirectService
      * @var RedirectStorageInterface
      */
     protected $redirectStorage;
-
-    /**
-     * @Flow\Inject
-     * @var RouterCachingService
-     */
-    protected $routerCachingService;
 
     /**
      * @Flow\InjectConfiguration(path="features")


### PR DESCRIPTION
Previously the whole target path including query and fragment were fed as
path into the new uri instead of setting each component. This caused
the query and fragment to be url encoded as path.

Resolves: #44 