### PR TITLE
BUGFIX: Prevent url encoding of query and fragments in relative redirects

### DIFF
--- a/Classes/RedirectComponent.php
+++ b/Classes/RedirectComponent.php
@@ -17,7 +17,6 @@ use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Http\Component\ComponentChain;
 use Neos\Flow\Http\Component\ComponentContext;
 use Neos\Flow\Http\Component\ComponentInterface;
-use Neos\Flow\Mvc\Routing\RouterCachingService;
 use Neos\Flow\Mvc\Routing\RoutingComponent;
 
 /**
@@ -25,11 +24,6 @@ use Neos\Flow\Mvc\Routing\RoutingComponent;
  */
 class RedirectComponent implements ComponentInterface
 {
-    /**
-     * @var RouterCachingService
-     * @Flow\Inject
-     */
-    protected $routerCachingService;
 
     /**
      * @var RedirectService

--- a/Classes/RedirectService.php
+++ b/Classes/RedirectService.php
@@ -13,10 +13,8 @@ namespace Neos\RedirectHandler;
  * source code.
  */
 
-use Neos\Flow\Http\ServerRequestAttributes;
 use Neos\RedirectHandler\Storage\RedirectStorageInterface;
 use Neos\Flow\Annotations as Flow;
-use Neos\Flow\Mvc\Routing\RouterCachingService;
 use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -36,12 +34,6 @@ class RedirectService
      * @var RedirectStorageInterface
      */
     protected $redirectStorage;
-
-    /**
-     * @Flow\Inject
-     * @var RouterCachingService
-     */
-    protected $routerCachingService;
 
     /**
      * @Flow\Inject

--- a/Classes/RedirectService.php
+++ b/Classes/RedirectService.php
@@ -96,29 +96,29 @@ class RedirectService
         $response = $this->responseFactory->createResponse($statusCode);
 
         if ($statusCode >= 300 && $statusCode <= 399) {
-            $location = $redirect->getTargetUriPath();
+            $targetUri = $redirect->getTargetUriPath();
 
             // Relative redirects will be turned into absolute redirects
-            if (parse_url($location, PHP_URL_SCHEME) === null) {
-                $locationParts = parse_url($location);
-                $location = $httpRequest->getUri();
+            if (parse_url($targetUri, PHP_URL_SCHEME) === null) {
+                $targetUriParts = parse_url($targetUri);
+                $absoluteTargetUri = $httpRequest->getUri();
 
-                if (isset($locationParts['path'])) {
-                    $location = $location->withPath($locationParts['path']);
+                if (isset($targetUriParts['path'])) {
+                    $absoluteTargetUri = $absoluteTargetUri->withPath($targetUriParts['path']);
                 }
 
-                if (isset($locationParts['query'])) {
-                    $location = $location->withQuery($locationParts['query']);
+                if (isset($targetUriParts['query'])) {
+                    $absoluteTargetUri = $absoluteTargetUri->withQuery($targetUriParts['query']);
                 }
 
-                if (isset($locationParts['fragment'])) {
-                    $location = $location->withFragment($locationParts['fragment']);
+                if (isset($targetUriParts['fragment'])) {
+                    $absoluteTargetUri = $absoluteTargetUri->withFragment($targetUriParts['fragment']);
                 }
 
-                $location = (string)$location;
+                $targetUri = (string)$absoluteTargetUri;
             }
 
-            $response = $response->withHeader('Location', $location)
+            $response = $response->withHeader('Location', $targetUri)
                 ->withHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0')
                 ->withHeader('Expires', 'Sat, 26 Jul 1997 05:00:00 GMT');
         } elseif ($statusCode >= 400 && $statusCode <= 599) {

--- a/Classes/RedirectService.php
+++ b/Classes/RedirectService.php
@@ -98,8 +98,24 @@ class RedirectService
         if ($statusCode >= 300 && $statusCode <= 399) {
             $location = $redirect->getTargetUriPath();
 
+            // Relative redirects will be turned into absolute redirects
             if (parse_url($location, PHP_URL_SCHEME) === null) {
-                $location = (string)$httpRequest->getUri()->withQuery('')->withFragment('')->withPath($location);
+                $locationParts = parse_url($location);
+                $location = $httpRequest->getUri();
+
+                if (isset($locationParts['path'])) {
+                    $location = $location->withPath($locationParts['path']);
+                }
+
+                if (isset($locationParts['query'])) {
+                    $location = $location->withQuery($locationParts['query']);
+                }
+
+                if (isset($locationParts['fragment'])) {
+                    $location = $location->withFragment($locationParts['fragment']);
+                }
+
+                $location = (string)$location;
             }
 
             $response = $response->withHeader('Location', $location)


### PR DESCRIPTION
This problem was introduced with version 4.0 as the target location was now built with a http request and the whole target uri was fed as path instead of the individual parts.

Resolves: #44 