### PR TITLE
Relax version constraint to allow master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,8 +4,8 @@
     "description": "Basic API to handle HTTP redirects with the Flow Framework",
     "license": "MIT",
     "require": {
-        "neos/flow": "^6.0",
-        "neos/redirecthandler-storageimplementation": "~3.0",
+        "neos/flow": "^6.0 || dev-master",
+        "neos/redirecthandler-storageimplementation": "~3.0 || dev-master",
         "league/csv": "^9.2",
         "ext-json": "*"
     },


### PR DESCRIPTION
Currently the redirecthandler cannot be installed on master flow