### PR TITLE
BUGFIX: Prevent encoded path in new redirect URI

### DIFF
--- a/Classes/RedirectService.php
+++ b/Classes/RedirectService.php
@@ -100,6 +100,7 @@ class RedirectService
 
             if (parse_url($location, PHP_URL_SCHEME) === null) {
                 $location = $httpRequest->getBaseUri() . $location;
+                $location = urldecode($location);
             }
 
             $response->setHeaders(new Headers([


### PR DESCRIPTION
The path in the new redirect URI encodes signs like `?`
To fix that, we decode the location before the new header is set.

When the `targetUriPath` contains a query string, this part will be encoded in the resolving URI.
Sadly, this leads to an 404 on the site.

Fixes: #47