### PR TITLE
Feature: Add ReturnTypeWillChange to jsonSerialize

### DIFF
--- a/Classes/Redirect.php
+++ b/Classes/Redirect.php
@@ -288,6 +288,7 @@ class Redirect implements RedirectInterface
     /**
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function jsonSerialize()
     {
         return [

--- a/Classes/Redirect.php
+++ b/Classes/Redirect.php
@@ -288,8 +288,7 @@ class Redirect implements RedirectInterface
     /**
      * @return mixed
      */
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             'host' => $this->getHost(),


### PR DESCRIPTION
On PHP 8.2 there is a deprecation Warning for the jsonSerialize. 
To disable the deprecation warning, I added #[\ReturnTypeWillChange]. 